### PR TITLE
Warn user when using a prod server with a dev app

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -39,7 +39,14 @@ public class EmbeddedBrowserActivity extends Activity {
 		this.requestWindowFeature(Window.FEATURE_NO_TITLE);
 		setContentView(R.layout.main);
 
-		container = (WebView) findViewById(R.id.WebViewContainer);
+		// Add an alarming red border if using configurable (i.e. dev)
+		// app with a medic production server.
+		if(settings.allowsConfiguration() &&
+				settings.getAppUrl().contains("app.medicmobile.org")) {
+			findViewById(R.id.lytWebView).setPadding(10, 10, 10, 10);
+		}
+
+		container = (WebView) findViewById(R.id.wbvMain);
 
 		if(DEBUG) enableWebviewLoggingAndDebugging(container);
 		enableJavascript(container);

--- a/src/main/res/drawable/warning_background.xml
+++ b/src/main/res/drawable/warning_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+		android:shape="rectangle">
+	<solid android:color="#ff0000"/>
+	<corners android:radius="10px"/>
+</shape>

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-		android:id="@+id/WebViewContainer"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+		android:id="@+id/lytWebView"
+		android:background="@drawable/warning_background"
 		android:layout_width="fill_parent"
-		android:layout_height="fill_parent"/>
+		android:layout_height="fill_parent">
+	<WebView android:id="@+id/wbvMain"
+			android:layout_width="fill_parent"
+			android:layout_height="fill_parent"/>
+</LinearLayout>


### PR DESCRIPTION
Add an alarming red border if using configurable (i.e. dev) app with a medic production server.