### PR TITLE
Enable proguard & shrinkResources for release builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,8 +145,9 @@ android {
 			testCoverageEnabled = true
 		}
 		release {
-			minifyEnabled false
-			proguardFile getDefaultProguardFile('proguard-android.txt')
+			minifyEnabled true
+			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'config/xwalk.pro'
+			shrinkResources true
 			signingConfig signingConfigs.release
 		}
 	}

--- a/config/xwalk.pro
+++ b/config/xwalk.pro
@@ -1,0 +1,16 @@
+# ProGuard config for Crosswalk
+
+-dontwarn javax.annotation.Nullable
+-dontwarn javax.annotation.Nonnull
+-dontwarn javax.annotation.concurrent.NotThreadSafe
+-dontwarn javax.annotation.concurrent.ThreadSafe
+
+-keep class org.xwalk.core.** {
+	*;
+}
+-keep class org.chromium.** {
+	*;
+}
+-keepattributes **
+
+-optimizations !code/allocation/variable


### PR DESCRIPTION
This includes proguard rules to ignore crosswalk core files, as advised at
https://crosswalk-project.org/documentation/about/faq.html