### PR TITLE
Handle photos on android 4.4 properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	compile 'com.android.support:appcompat-v7:21.0.3'
 	compile 'org.xwalk:xwalk_core_library:23.53.589.4:arm@aar'
 	compile 'com.simprints:LibSimprints:1.0.8'
-	compile 'com.github.alxndrsn:ImagePicker:1.0.0-medic'
+	compile 'com.github.Mariovc:ImagePicker:1.2.0'
 }
 
 def getVersionCode = {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -14,8 +14,10 @@
 	<uses-permission android:name="android.permission.VIBRATE"/>
 	<uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
 	<uses-permission android:name="com.android.launcher.permission.UNINSTALL_SHORTCUT"/>
-	<!-- READ_EXTERNAL_STORAGE required if users want to include photos from their phone -->
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+	<!-- READ_EXTERNAL_STORAGE required if users want to include photos from their phone;
+	     WRITE_EXTERNAL_STORAGE required for taking new photos, and our resizing code.
+	     WRITE implies READ. -->
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<application android:label="@string/app_name"
 			android:icon="@mipmap/ic_launcher"
 			android:allowBackup="false"

--- a/src/main/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
@@ -1,0 +1,200 @@
+package org.medicmobile.webapp.mobile;
+
+import android.app.Activity;
+import android.app.ProgressDialog;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Matrix;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.webkit.ValueCallback;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static android.app.Activity.RESULT_OK;
+import static android.provider.MediaStore.ACTION_IMAGE_CAPTURE;
+import static com.mvc.imagepicker.ImagePicker.getImageFromResult;
+import static com.mvc.imagepicker.ImagePicker.getPickImageIntent;
+import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_PHOTO;
+import static org.medicmobile.webapp.mobile.MedicLog.trace;
+import static org.medicmobile.webapp.mobile.MedicLog.warn;
+import static org.medicmobile.webapp.mobile.Utils.intentHandlerAvailableFor;
+import static org.medicmobile.webapp.mobile.Utils.showSpinner;
+
+class PhotoGrabber {
+	/** Max permitted file size for uploaded photos, in bytes. */
+	private static final long MAX_FILE_SIZE = 1 << 15; // 32kb
+	/** Smallest permitted image dimension in pixels */
+	private static final int MINIMUM_DIMENSION = 240;
+	/**
+	 * This is actually the value of
+	 * {@code ImagePicker.DEFAULT_REQUEST_CODE}.  This value is not exposed
+	 * by the library, but needs to be supplied to
+	 * {@code getImageFromResult()} so that it properly returns the full-
+	 * size image.
+	 */
+	private static final int FAKE_REQUEST_CODE = 234;
+
+	private final Activity a;
+
+	private ValueCallback<Uri> uploadCallback;
+
+	PhotoGrabber(Activity a) {
+		this.a = a;
+	}
+
+//> EXTERNAL METHODS
+	boolean canHandle(String acceptType, boolean capture) {
+		return acceptType.startsWith("image/") && (!capture || canStartCamera());
+	}
+
+	void chooser(ValueCallback<Uri> callback, boolean capture) {
+		uploadCallback = callback;
+		if(capture) takePhoto();
+		else pickImage();
+	}
+
+	void process(int requestCode, int resultCode, Intent i) {
+		if(uploadCallback == null) {
+			warn(this, "uploadCallback is null for requestCode %s", requestCode);
+			return;
+		}
+
+		if(resultCode != RESULT_OK) {
+			trace(this, "process() :: non-OK result code :: resultCode=%s, i=%s, intentData=%s", i, resultCode, i.getData());
+		} else {
+			try {
+				handleBitmapCallback(getImageFromResult(a, FAKE_REQUEST_CODE, resultCode, i));
+				return;
+			} catch(Exception ex) {
+				warn(ex, "process() :: error getting image from result");
+			}
+		}
+
+		handleNullCallback();
+	}
+
+//> PRIVATE HELPERS
+	private void handleNullCallback() {
+		uploadCallback.onReceiveValue(null);
+		uploadCallback = null;
+	}
+
+	private void handleBitmapCallback(final Bitmap bitmap) {
+		trace(this, "handleBitmapCallback() :: bitmap=%s", bitmap);
+		final ProgressDialog spinner = showSpinner(a, R.string.spnCompressingImage);
+		AsyncTask.execute(new Runnable() {
+			public void run() {
+				Uri uri = null;
+				try {
+					uri = writeToFile(bitmap);
+					trace(this, "process() :: image written to temp file.  uri=%s", uri);
+				} catch(Exception ex) {
+					warn(ex, "process() :: error writing image to temp file");
+				}
+				spinner.dismiss();
+
+				uploadCallback.onReceiveValue(uri);
+				uploadCallback = null;
+			}
+		});
+	}
+
+	private void takePhoto() {
+		a.startActivityForResult(cameraIntent(), GRAB_PHOTO);
+	}
+
+	private void pickImage() {
+		Intent i = getPickImageIntent(a, a.getString(R.string.promptChooseImage));
+		a.startActivityForResult(i, GRAB_PHOTO);
+	}
+
+	private boolean canStartCamera() {
+		return intentHandlerAvailableFor(a, cameraIntent());
+	}
+
+	private static Intent cameraIntent() {
+		return new Intent(ACTION_IMAGE_CAPTURE);
+	}
+
+	/**
+	 * Write the supplied {@code Bitmap} to a random file location.
+	 *
+	 * Android documentation suggests that while these are nominally "temp"
+	 * files, they may not be cleaned up automatically.  For now, this may
+	 * be considered a useful feature.
+	 *
+	 * @return the {@code android.net.Uri} of the created file
+	 */
+	private Uri writeToFile(Bitmap bitmap) throws IOException {
+		File temp = tempFile();
+		long tempFileSize = -1;
+		int quality;
+
+		do {
+			for(quality=90; quality>=50; quality-=10) {
+				trace(this, "writeToFile() :: Attempting to write bitmap=%s (%sx%s) to file=%s at quality=%s; size of last write=%s...",
+						bitmap, bitmap.getWidth(), bitmap.getHeight(), temp, quality, tempFileSize);
+
+				writeToFile(temp, bitmap, quality);
+
+				tempFileSize = temp.length();
+
+				if(tempFileSize <= MAX_FILE_SIZE) {
+					trace(this, "writeToFile() :: wrote temp file %s with %s bytes (max size = %s bytes)", temp, tempFileSize, MAX_FILE_SIZE);
+					return Uri.fromFile(temp);
+				}
+
+			}
+
+			bitmap = downsize(bitmap);
+
+		} while(bitmap.getWidth() > MINIMUM_DIMENSION && bitmap.getHeight() > MINIMUM_DIMENSION);
+
+		warn(this, "Failed to compress image small enough.  Final quality=%s, tempFileSize=%s", quality, tempFileSize);
+		return null;
+	}
+
+	private void writeToFile(File file, Bitmap bitmap, int quality) throws IOException {
+		FileOutputStream fos = null;
+		try {
+			fos = new FileOutputStream(file);
+			bitmap.compress(Bitmap.CompressFormat.JPEG, quality, fos);
+		} finally {
+			if(fos != null) try {
+				fos.close();
+			} catch(IOException ex) {
+				warn(ex, "writeToFile() :: exception closing FileOutputStream to %s", file);
+			}
+		}
+	}
+
+	/**
+	 * @see https://stackoverflow.com/questions/4837715/how-to-resize-a-bitmap-in-android#10703256
+	 */
+	private Bitmap downsize(Bitmap bm) {
+		int width = bm.getWidth();
+		int height = bm.getHeight();
+
+		float scaleWidth = 0.5f;
+		float scaleHeight = 0.5f;
+
+		// CREATE A MATRIX FOR THE MANIPULATION
+		Matrix matrix = new Matrix();
+		// RESIZE THE BIT MAP
+		matrix.postScale(scaleWidth, scaleHeight);
+
+		// "RECREATE" THE NEW BITMAP
+		Bitmap resizedBitmap = Bitmap.createBitmap(bm, 0, 0, width, height, matrix, false);
+		bm.recycle();
+		return resizedBitmap;
+	}
+
+	private File tempFile() throws IOException {
+		File imageCacheDir = new File(a.getCacheDir(), "medic-form-photos");
+		imageCacheDir.mkdirs();
+		return File.createTempFile("photo", ".jpg", imageCacheDir);
+	}
+}

--- a/src/main/java/org/medicmobile/webapp/mobile/Utils.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/Utils.java
@@ -1,6 +1,7 @@
 package org.medicmobile.webapp.mobile;
 
 import android.app.Activity;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 
@@ -32,5 +33,19 @@ final class Utils {
 			a.startActivity(new Intent(a, SettingsDialogActivity.class));
 			a.finish();
 		}
+	}
+
+	public static ProgressDialog showSpinner(Context ctx, int messageId) {
+		return showSpinner(ctx, ctx.getString(messageId));
+	}
+
+	public static ProgressDialog showSpinner(Context ctx, String message) {
+		ProgressDialog p = new ProgressDialog(ctx);
+		p.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+		if(message != null) p.setMessage(message);
+		p.setIndeterminate(true);
+		p.setCanceledOnTouchOutside(false);
+		p.show();
+		return p;
 	}
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
 	<string name="promptChooseFile">Choose file</string>
 	<string name="promptChooseImage">Choose image</string>
 
+	<string name="spnCompressingImage">Compressing image…</string>
 
 	<string name="txtPermissionsPrompt_location">
 		<![CDATA[


### PR DESCRIPTION
On some handsets, we're provided with photos in the intent data extra instead of just being provided with the URI to the content of the photo.  In these cases, we need to write the supplied data to a file, and provide this file's URI to the webview.