### PR TITLE
GPS check before requesting location updates from GPS

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -321,8 +321,8 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 				public void onStatusChanged(String provider, int status, Bundle extras) {}
 			});
 		}else {
-            log("GPS not enabled or phone does not have GPS.");
-        }
+			log("GPS not enabled or phone does not have GPS.");
+		}
 
 		m.requestLocationUpdates(NETWORK_PROVIDER, FIVE_MINS, ANY_DISTANCE, new LocationListener() {
 			public void onLocationChanged(Location location) {}

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -312,12 +312,17 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 
 		LocationManager m = (LocationManager) this.getSystemService(Context.LOCATION_SERVICE);
 
-		m.requestLocationUpdates(GPS_PROVIDER, FIVE_MINS, ANY_DISTANCE, new LocationListener() {
-			public void onLocationChanged(Location location) {}
-			public void onProviderDisabled(String provider) {}
-			public void onProviderEnabled(String provider) {}
-			public void onStatusChanged(String provider, int status, Bundle extras) {}
-		});
+		// Checking if the phone has GPS or GPS needs to be enabled before requesting GPS location updates
+		if(m.isProviderEnabled(LocationManager.GPS_PROVIDER)){
+			m.requestLocationUpdates(GPS_PROVIDER, FIVE_MINS, ANY_DISTANCE, new LocationListener() {
+				public void onLocationChanged(Location location) {}
+				public void onProviderDisabled(String provider) {}
+				public void onProviderEnabled(String provider) {}
+				public void onStatusChanged(String provider, int status, Bundle extras) {}
+			});
+		}else {
+            log("GPS not enabled or phone does not have GPS.");
+        }
 
 		m.requestLocationUpdates(NETWORK_PROVIDER, FIVE_MINS, ANY_DISTANCE, new LocationListener() {
 			public void onLocationChanged(Location location) {}


### PR DESCRIPTION
With regards to [this ticket](https://github.com/medic/medic-projects/issues/4317) , @Mercyamulele   I and @ngamita (from communication) have experienced some phones which are crashing after accepting the fine location permission and opening the app in the first launch and subsequent times. Most of these devices are said to be Tecno phones with version 6.0 and above.
 
I was able to get hold of one phone which was experience this and these are the phone specs of the sample phone I was testing.

# a sample device experiencing this

key | value(s)
---|---
device make | _Tecno_
device model | _W2_
android version | _6.0_
can the problem be recreated on this device? | _yes_

Yesterday at night I tested the phone after running this fix and the phone was no longer crashing.
