### PR TITLE
Navigate to root instead of the _rewrite path (after webapp 3.5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ android {
 
 	applicationVariants.all {
 		buildConfigField "boolean", "DISABLE_APP_URL_VALIDATION", "Boolean.parseBoolean(\"${System.env.DISABLE_APP_URL_VALIDATION}\")";
+		buildConfigField "boolean", "USE_URL_ROOT_PATH", "Boolean.parseBoolean(\"${System.env.USE_URL_ROOT_PATH}\")";
 		buildConfigField "String", "LOG_TAG", '"MedicMobile"'
 
 		if(System.env.SIMPRINTS_API_KEY) {

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -34,6 +34,7 @@ import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static java.lang.Boolean.parseBoolean;
 import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
 import static org.medicmobile.webapp.mobile.BuildConfig.DISABLE_APP_URL_VALIDATION;
+import static org.medicmobile.webapp.mobile.BuildConfig.USE_URL_ROOT_PATH;
 import static org.medicmobile.webapp.mobile.MedicLog.error;
 import static org.medicmobile.webapp.mobile.MedicLog.log;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
@@ -257,8 +258,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	}
 
 	private String getRootUrl() {
-		return appUrl + (DISABLE_APP_URL_VALIDATION ?
-				"" : "/medic/_design/medic/_rewrite/");
+		return appUrl + (USE_URL_ROOT_PATH || DISABLE_APP_URL_VALIDATION ? "" : "/medic/_design/medic/_rewrite/");
 	}
 
 	private void browseToRoot() {


### PR DESCRIPTION
#94

WebApp v3.5 uses the domain's root url instead of the `/medic/_design/medic/_rewrite/` path. The app directly navigates to this rewrite path, which then redirects to root. This adds an extra layer of complexity to the cache and an unnecessary redirect. This change introduces a build-time switch `USE_URL_ROOT_PATH` which uses the root path instead of the rewrite path when set.