### PR TITLE
fixes gradle sync error and warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ android {
 		versionCode getVersionCode()
 		versionName getVersionName()
 		archivesBaseName = "${project.name}-${versionName}"
+		minSdkVersion 19
 	}
 
 	applicationVariants.all {

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ android {
 		versionName getVersionName()
 		archivesBaseName = "${project.name}-${versionName}"
 		minSdkVersion 19
+		targetSdkVersion 26
 	}
 
 	applicationVariants.all {

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ android {
 
 		disable 'UnusedResources' // linter can't handle static imports, so just skip this test
 		disable 'GradleDependency' // TODO update to latest support-v4 lib and re-enable this rule
+		disable 'OldTargetApi'
 
 		warningsAsErrors true
 

--- a/src/hope_through_health/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/src/hope_through_health/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/src/hope_through_health/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/src/hope_through_health/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
 		package="org.medicmobile.webapp.mobile">
 	<!-- When upgrading targetSdkVersion, check that the app menu still
 			works on newer devices. -->
-	<uses-sdk
-		android:targetSdkVersion="26"
-			tools:ignore="OldTargetApi"/>
+	<uses-sdk tools:ignore="OldTargetApi"/>
 
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -4,8 +4,8 @@
 		package="org.medicmobile.webapp.mobile">
 	<!-- When upgrading targetSdkVersion, check that the app menu still
 			works on newer devices. -->
-	<uses-sdk android:minSdkVersion="19"
-			android:targetSdkVersion="26"
+	<uses-sdk
+		android:targetSdkVersion="26"
 			tools:ignore="OldTargetApi"/>
 
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>


### PR DESCRIPTION
Moving from AndroidManifest.xml to build.gradle to fix an error(minSdkVersion) and warning(targetSdkVersion) for gradle sync.  #72 