### PR TITLE
replaced defunct default servers

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/SettingsDialogActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SettingsDialogActivity.java
@@ -230,8 +230,8 @@ class ServerRepo {
 		prefs = ctx.getSharedPreferences(
 				"ServerRepo",
 				Context.MODE_PRIVATE);
-		save("https://alpha.dev.medicmobile.org");
-		save("https://beta.dev.medicmobile.org");
+		save("https://gamma.dev.medicmobile.org");
+		save("https://gamma-cht.dev.medicmobile.org");
 		save("https://medic.github.io/atp");
 	}
 


### PR DESCRIPTION
The old `alpha.dev` and `beta.dev` are no longer live. Changing to working urls, used for release testing (`gamma.de` and `gamma-cht.dev`. 