### PR TITLE
Adds intent for fixed_app_url 

### DIFF
--- a/src/bracuganda/res/values/strings.xml
+++ b/src/bracuganda/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">BRAC</string>
-	<string name="fixed_app_url">https://brac-ug.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">brac-ug.app.medicmobile.org</string>
 </resources>

--- a/src/bracuganda/res/values/strings.xml
+++ b/src/bracuganda/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">BRAC</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">brac-ug.app.medicmobile.org</string>
+	<string name="app_host">brac-ug.app.medicmobile.org</string>
 </resources>

--- a/src/cic_guatemala/res/values/strings.xml
+++ b/src/cic_guatemala/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CiC Tijax</string>
-	<string name="fixed_app_url">https://cic-guatemalav2.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">cic-guatemalav2.app.medicmobile.org</string>
 </resources>

--- a/src/cic_guatemala/res/values/strings.xml
+++ b/src/cic_guatemala/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CiC Tijax</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">cic-guatemalav2.app.medicmobile.org</string>
+	<string name="app_host">cic-guatemalav2.app.medicmobile.org</string>
 </resources>

--- a/src/cmmb_kenya/res/values/strings.xml
+++ b/src/cmmb_kenya/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CMMB MHealth - Kitui</string>
-	<string name="fixed_app_url">https://cmmb-kenya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">cmmb-kenya.app.medicmobile.org</string>
 </resources>

--- a/src/cmmb_kenya/res/values/strings.xml
+++ b/src/cmmb_kenya/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CMMB MHealth - Kitui</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">cmmb-kenya.app.medicmobile.org</string>
+	<string name="app_host">cmmb-kenya.app.medicmobile.org</string>
 </resources>

--- a/src/ebpp_indonesia/res/values/strings.xml
+++ b/src/ebpp_indonesia/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Yayasan Ekoturin</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">ebpp-indonesia.app.medicmobile.org</string>
+	<string name="app_host">ebpp-indonesia.app.medicmobile.org</string>
 </resources>

--- a/src/ebpp_indonesia/res/values/strings.xml
+++ b/src/ebpp_indonesia/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Yayasan Ekoturin</string>
-	<string name="fixed_app_url">https://ebpp-indonesia.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">ebpp-indonesia.app.medicmobile.org</string>
 </resources>

--- a/src/hope_through_health/res/values/strings.xml
+++ b/src/hope_through_health/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Hope Through Health</string>
-	<string name="fixed_app_url">https://hth-togo.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">hth-togo.app.medicmobile.org</string>
 </resources>

--- a/src/hope_through_health/res/values/strings.xml
+++ b/src/hope_through_health/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Hope Through Health</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">hth-togo.app.medicmobile.org</string>
+	<string name="app_host">hth-togo.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods/res/values/strings.xml
+++ b/src/livinggoods/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods</string>
-	<string name="fixed_app_url">https://lg.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">lg.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods/res/values/strings.xml
+++ b/src/livinggoods/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">lg.app.medicmobile.org</string>
+	<string name="app_host">lg.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_assisted_networks/res/values/strings.xml
+++ b/src/livinggoods_assisted_networks/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CHV - Toolkit</string>
-	<string name="fixed_app_url">https://kisii-an.app.smarthealth.livinggoods.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">kisii-an.app.smarthealth.livinggoods.org</string>
 </resources>

--- a/src/livinggoods_assisted_networks/res/values/strings.xml
+++ b/src/livinggoods_assisted_networks/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">CHV - Toolkit</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">kisii-an.app.smarthealth.livinggoods.org</string>
+	<string name="app_host">kisii-an.app.smarthealth.livinggoods.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods (Innovation Network)</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">lg-innovation-ke.app.medicmobile.org</string>
+	<string name="app_host">lg-innovation-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods (Innovation Network)</string>
-	<string name="fixed_app_url">https://lg-innovation-ke.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">lg-innovation-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke_hivst/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke_hivst/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods (Innovation - HIVST)</string>
-	<string name="fixed_app_url">https://lg-innovation-hivst-facility-ke.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">lg-innovation-hivst-facility-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke_hivst/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke_hivst/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods (Innovation - HIVST)</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">lg-innovation-hivst-facility-ke.app.medicmobile.org</string>
+	<string name="app_host">lg-innovation-hivst-facility-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke_supervisor/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke_supervisor/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods Supervisor (Innovation Network)</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">lg-innovation-facility-ke.app.medicmobile.org</string>
+	<string name="app_host">lg-innovation-facility-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoods_innovation_ke_supervisor/res/values/strings.xml
+++ b/src/livinggoods_innovation_ke_supervisor/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods Supervisor (Innovation Network)</string>
-	<string name="fixed_app_url">https://lg-innovation-facility-ke.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">lg-innovation-facility-ke.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoodskenya/res/values/strings.xml
+++ b/src/livinggoodskenya/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods</string>
-	<string name="fixed_app_url">https://lg-kenya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">lg-kenya.app.medicmobile.org</string>
 </resources>

--- a/src/livinggoodskenya/res/values/strings.xml
+++ b/src/livinggoodskenya/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Living Goods</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">lg-kenya.app.medicmobile.org</string>
+	<string name="app_host">lg-kenya.app.medicmobile.org</string>
 </resources>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
         android:screenOrientation="portrait"/>
     <activity android:name="SettingsDialogActivity"
         android:screenOrientation="portrait"/>
-    <activity android:name="TokenLogin" android:launchMode="singleInstance">
+    <activity android:name="AppUrlIntentActivity" android:launchMode="singleInstance">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="@string/scheme" android:host="@string/fixed_app_url" android:pathPattern=".*"/>
+        <data android:scheme="@string/scheme" android:host="@string/app_host" android:pathPattern=".*"/>
       </intent-filter>
     </activity>
   </application>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -47,5 +47,13 @@
         android:screenOrientation="portrait"/>
     <activity android:name="SettingsDialogActivity"
         android:screenOrientation="portrait"/>
+    <activity android:name="TokenLogin" android:launchMode="singleInstance">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="@string/scheme" android:host="@string/fixed_app_url" android:pathPattern=".*"/>
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/src/main/java/org/medicmobile/webapp/mobile/AppUrlIntentActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/AppUrlIntentActivity.java
@@ -8,7 +8,7 @@ import android.net.Uri;
 import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 
-public class TokenLogin extends Activity {
+public class AppUrlIntentActivity extends Activity {
 	@Override public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		Intent appLinkIntent = getIntent();

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -118,7 +118,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 
 		Intent appLinkIntent = getIntent();
 		Uri appLinkData = appLinkIntent.getData();
-		browse(appLinkData);
+		browseTo(appLinkData);
 
 		if(settings.allowsConfiguration()) {
 			toast(redactUrl(appUrl));
@@ -146,7 +146,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 				openSettings();
 				return true;
 			case R.id.mnuHardRefresh:
-				browseToRoot();
+				browseTo(null);
 				return true;
 			case R.id.mnuLogout:
 				evaluateJavascript("angular.element(document.body).injector().get('AndroidApi').v1.logout()");
@@ -265,18 +265,17 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 				"" : "/medic/_design/medic/_rewrite/");
 	}
 
-	private void browse(Uri url) {
+	private String getUrlToLoad(Uri url) {
 		if (url != null) {
-			container.load(url.toString(), null);
-		} else {
-			browseToRoot();
+			return url.toString();
 		}
+		return getRootUrl();
 	}
 
-	private void browseToRoot() {
-		String url = getRootUrl();
-		if(DEBUG) trace(this, "Pointing browser to %s", redactUrl(url));
-		container.load(url, null);
+	private void browseTo(Uri url) {
+		String urlToLoad = getUrlToLoad(url);
+		if(DEBUG) trace(this, "Pointing browser to %s", redactUrl(urlToLoad));
+		container.load(urlToLoad, null);
 	}
 
 	private void enableRemoteChromeDebugging() {

--- a/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -116,7 +116,9 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 
 		enableUrlHandlers(container);
 
-		browseToRoot();
+		Intent appLinkIntent = getIntent();
+		Uri appLinkData = appLinkIntent.getData();
+		browse(appLinkData);
 
 		if(settings.allowsConfiguration()) {
 			toast(redactUrl(appUrl));
@@ -261,6 +263,14 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	private String getRootUrl() {
 		return appUrl + (DISABLE_APP_URL_VALIDATION ?
 				"" : "/medic/_design/medic/_rewrite/");
+	}
+
+	private void browse(Uri url) {
+		if (url != null) {
+			container.load(url.toString(), null);
+		} else {
+			browseToRoot();
+		}
 	}
 
 	private void browseToRoot() {

--- a/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
@@ -59,10 +59,10 @@ public abstract class SettingsStore {
 				SettingsStore.class.getName(),
 				Context.MODE_PRIVATE);
 
-		String fixedAppUrl = ctx.getResources().
-				getString(R.string.fixed_app_url);
+		String fixedAppUrl = ctx.getResources().getString(R.string.fixed_app_url);
+		String scheme = ctx.getResources().getString(R.string.scheme);
 		if(fixedAppUrl.length() > 0) {
-			return new BrandedSettingsStore(prefs, fixedAppUrl);
+			return new BrandedSettingsStore(prefs, scheme + "://" + fixedAppUrl);
 		}
 
 		return new UnbrandedSettingsStore(prefs);

--- a/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/SettingsStore.java
@@ -59,10 +59,10 @@ public abstract class SettingsStore {
 				SettingsStore.class.getName(),
 				Context.MODE_PRIVATE);
 
-		String fixedAppUrl = ctx.getResources().getString(R.string.fixed_app_url);
+		String appHost = ctx.getResources().getString(R.string.app_host);
 		String scheme = ctx.getResources().getString(R.string.scheme);
-		if(fixedAppUrl.length() > 0) {
-			return new BrandedSettingsStore(prefs, scheme + "://" + fixedAppUrl);
+		if(appHost.length() > 0) {
+			return new BrandedSettingsStore(prefs, scheme + "://" + appHost);
 		}
 
 		return new UnbrandedSettingsStore(prefs);

--- a/src/main/java/org/medicmobile/webapp/mobile/TokenLogin.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/TokenLogin.java
@@ -1,0 +1,23 @@
+package org.medicmobile.webapp.mobile;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.net.Uri;
+
+import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
+import static org.medicmobile.webapp.mobile.MedicLog.trace;
+import static org.medicmobile.webapp.mobile.SimpleJsonClient2.redactUrl;
+
+public class TokenLogin extends Activity {
+    @Override public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent appLinkIntent = getIntent();
+        Uri appLinkData = appLinkIntent.getData();
+
+        if(DEBUG) trace(this, "TOKEN LOGIN=%s", appLinkData.toString());
+
+        startActivity(new Intent(Intent.ACTION_VIEW, appLinkData, this, EmbeddedBrowserActivity.class));
+        finish();
+    }
+}

--- a/src/main/java/org/medicmobile/webapp/mobile/TokenLogin.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/TokenLogin.java
@@ -7,17 +7,16 @@ import android.net.Uri;
 
 import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
-import static org.medicmobile.webapp.mobile.SimpleJsonClient2.redactUrl;
 
 public class TokenLogin extends Activity {
-    @Override public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        Intent appLinkIntent = getIntent();
-        Uri appLinkData = appLinkIntent.getData();
+	@Override public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		Intent appLinkIntent = getIntent();
+		Uri appLinkData = appLinkIntent.getData();
 
-        if(DEBUG) trace(this, "TOKEN LOGIN=%s", appLinkData.toString());
+		if(DEBUG) trace(this, "TOKEN LOGIN=%s", appLinkData.toString());
 
-        startActivity(new Intent(Intent.ACTION_VIEW, appLinkData, this, EmbeddedBrowserActivity.class));
-        finish();
-    }
+		startActivity(new Intent(Intent.ACTION_VIEW, appLinkData, this, EmbeddedBrowserActivity.class));
+		finish();
+	}
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -2,7 +2,8 @@
 <resources>
 	<string name="app_name">Medic Mobile</string>
 
-	<string name="fixed_app_url"/>
+	<string name="scheme">https</string>
+	<string name="app_host"/>
 
 	<string name="txtAppUrl">Webapp URL</string>
 	<string name="errAppUrl_serverNotFound">unable to contact server</string>

--- a/src/medicmobiledemo/res/values/strings.xml
+++ b/src/medicmobiledemo/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Medic Mobile (demo)</string>
-	<string name="fixed_app_url">https://demo.dev.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">demo.dev.medicmobile.org</string>
 </resources>

--- a/src/medicmobiledemo/res/values/strings.xml
+++ b/src/medicmobiledemo/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Medic Mobile (demo)</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">demo.dev.medicmobile.org</string>
+	<string name="app_host">demo.dev.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_black/res/values/strings.xml
+++ b/src/moh_kenya_siaya_black/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Black</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="app_host">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_black/res/values/strings.xml
+++ b/src/moh_kenya_siaya_black/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Black</string>
-	<string name="fixed_app_url">https://moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_green/res/values/strings.xml
+++ b/src/moh_kenya_siaya_green/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Green</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="app_host">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_green/res/values/strings.xml
+++ b/src/moh_kenya_siaya_green/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Green</string>
-	<string name="fixed_app_url">https://moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_red/res/values/strings.xml
+++ b/src/moh_kenya_siaya_red/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Red</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="app_host">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_red/res/values/strings.xml
+++ b/src/moh_kenya_siaya_red/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya Red</string>
-	<string name="fixed_app_url">https://moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_white/res/values/strings.xml
+++ b/src/moh_kenya_siaya_white/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya White</string>
-	<string name="fixed_app_url">https://moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_kenya_siaya_white/res/values/strings.xml
+++ b/src/moh_kenya_siaya_white/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">MOH Siaya White</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-kenya-siaya.app.medicmobile.org</string>
+	<string name="app_host">moh-kenya-siaya.app.medicmobile.org</string>
 </resources>

--- a/src/moh_mali/res/values/strings.xml
+++ b/src/moh_mali/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">ASA-MALI</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">supervisor-moh-mali.app.medicmobile.org</string>
+	<string name="app_host">supervisor-moh-mali.app.medicmobile.org</string>
 </resources>

--- a/src/moh_mali/res/values/strings.xml
+++ b/src/moh_mali/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">ASA-MALI</string>
-	<string name="fixed_app_url">https://supervisor-moh-mali.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">supervisor-moh-mali.app.medicmobile.org</string>
 </resources>

--- a/src/moh_zanzibar/res/values/strings.xml
+++ b/src/moh_zanzibar/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Jamii ni Afya</string>
-	<string name="fixed_app_url">https://moh-zanzibar.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-zanzibar.app.medicmobile.org</string>
 </resources>

--- a/src/moh_zanzibar/res/values/strings.xml
+++ b/src/moh_zanzibar/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Jamii ni Afya</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-zanzibar.app.medicmobile.org</string>
+	<string name="app_host">moh-zanzibar.app.medicmobile.org</string>
 </resources>

--- a/src/moh_zanzibar_training/res/values/strings.xml
+++ b/src/moh_zanzibar_training/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Darasa</string>
-	<string name="fixed_app_url">https://moh-zanzibar.dev.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">moh-zanzibar.dev.medicmobile.org</string>
 </resources>

--- a/src/moh_zanzibar_training/res/values/strings.xml
+++ b/src/moh_zanzibar_training/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Darasa</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">moh-zanzibar.dev.medicmobile.org</string>
+	<string name="app_host">moh-zanzibar.dev.medicmobile.org</string>
 </resources>

--- a/src/musomali/res/values/strings.xml
+++ b/src/musomali/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">muso</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">muso-mali.app.medicmobile.org</string>
+	<string name="app_host">muso-mali.app.medicmobile.org</string>
 </resources>

--- a/src/musomali/res/values/strings.xml
+++ b/src/musomali/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">muso</string>
-	<string name="fixed_app_url">https://muso-mali.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">muso-mali.app.medicmobile.org</string>
 </resources>

--- a/src/pih_malawi/res/values/strings.xml
+++ b/src/pih_malawi/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">YendaNafe</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">pih-malawi.app.medicmobile.org</string>
+	<string name="app_host">pih-malawi.app.medicmobile.org</string>
 </resources>

--- a/src/pih_malawi/res/values/strings.xml
+++ b/src/pih_malawi/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">YendaNafe</string>
-	<string name="fixed_app_url">https://pih-malawi.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">pih-malawi.app.medicmobile.org</string>
 </resources>

--- a/src/pih_malawi_supervisor/res/values/strings.xml
+++ b/src/pih_malawi_supervisor/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">YendaNafe Supervisor</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">pih-malawi.app.medicmobile.org</string>
+	<string name="app_host">pih-malawi.app.medicmobile.org</string>
 </resources>

--- a/src/pih_malawi_supervisor/res/values/strings.xml
+++ b/src/pih_malawi_supervisor/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">YendaNafe Supervisor</string>
-	<string name="fixed_app_url">https://pih-malawi.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">pih-malawi.app.medicmobile.org</string>
 </resources>

--- a/src/simprints/res/values/strings.xml
+++ b/src/simprints/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Medic Mobile - Simprints</string>
-	<string name="fixed_app_url">https://simprints.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">simprints.app.medicmobile.org</string>
 </resources>

--- a/src/simprints/res/values/strings.xml
+++ b/src/simprints/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Medic Mobile - Simprints</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">simprints.app.medicmobile.org</string>
+	<string name="app_host">simprints.app.medicmobile.org</string>
 </resources>

--- a/src/surveillance_covid19_kenya/res/values/strings.xml
+++ b/src/surveillance_covid19_kenya/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Kenya Covid-19 Tracker</string>
-	<string name="fixed_app_url">https://tracing-covid19.health.go.ke</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">tracing-covid19.health.go.ke</string>
 </resources>

--- a/src/surveillance_covid19_kenya/res/values/strings.xml
+++ b/src/surveillance_covid19_kenya/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Kenya Covid-19 Tracker</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">tracing-covid19.health.go.ke</string>
+	<string name="app_host">tracing-covid19.health.go.ke</string>
 </resources>

--- a/src/unbranded/res/values/strings.xml
+++ b/src/unbranded/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url"></string>
+</resources>

--- a/src/unbranded/res/values/strings.xml
+++ b/src/unbranded/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url"></string>
-</resources>

--- a/src/vhw_burundi/res/values/strings.xml
+++ b/src/vhw_burundi/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Village Health Works Burundi</string>
-	<string name="fixed_app_url">https://villagehealthworks-burundi.app.medicmobile.org</string>
+	<string name="scheme">https</string>
+	<string name="fixed_app_url">villagehealthworks-burundi.app.medicmobile.org</string>
 </resources>

--- a/src/vhw_burundi/res/values/strings.xml
+++ b/src/vhw_burundi/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="app_name">Village Health Works Burundi</string>
-	<string name="scheme">https</string>
-	<string name="fixed_app_url">villagehealthworks-burundi.app.medicmobile.org</string>
+	<string name="app_host">villagehealthworks-burundi.app.medicmobile.org</string>
 </resources>


### PR DESCRIPTION
When any link that has the same scheme and host as the branded flavor is clicked on the device, the user will have the option to open the link in the medic app. 

medic/cht-core#6380