### PR TITLE
Split fastlane build and deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,42 +27,45 @@ jobs:
       script: fastlane build flavor:medicmobiledemo
   
     - stage: final
-      - script:
-        - fastlane build flavor:unbranded
-        - fastlane build flavor:medicmobilegamma
-        - fastlane build flavor:medicmobiledemo
-      - script:
-        - fastlane build flavor:bracuganda
-        - fastlane build flavor:cic_guatemala
-      - script:
-        - fastlane build flavor:cmmb_kenya
-        - fastlane build flavor:ebpp_indonesia
-        - fastlane build flavor:hope_through_health
-      - script:
-        - fastlane build flavor:livinggoods
-        - fastlane build flavor:livinggoodskenya
-        - fastlane build flavor:livinggoods_assisted_networks
-      - script:
-        - fastlane build flavor:livinggoods_innovation_ke
-        - fastlane build flavor:livinggoods_innovation_ke_supervisor
-        - fastlane build flavor:livinggoods_innovation_ke_hivst
-      - script:
-  #     - fastlane build flavor:moh_kenya_siaya_white
-        - fastlane build flavor:moh_kenya_siaya_red
-        - fastlane build flavor:moh_kenya_siaya_green
-        - fastlane build flavor:moh_kenya_siaya_black
-        - fastlane build flavor:moh_mali
-      - script:
-        - fastlane build flavor:moh_zanzibar_training
-        - fastlane build flavor:moh_zanzibar
-      - script:
-        - fastlane build flavor:musomali
-        - fastlane build flavor:pih_malawi
-        - fastlane build flavor:pih_malawi_supervisor
-      - script:
-        - fastlane build flavor:simprints
-        - fastlane build flavor:surveillance_covid19_kenya
-        - fastlane build flavor:vhw_burundi
+    # flavors sorted alphabetically with three per job
+      script:
+      - fastlane build flavor:unbranded
+      - fastlane build flavor:medicmobilegamma
+      - fastlane build flavor:medicmobiledemo
+    - script:
+      - fastlane build flavor:bracuganda
+      - fastlane build flavor:cic_guatemala
+      - fastlane build flavor:cmmb_kenya
+    - script:
+      - fastlane build flavor:covid_moh_mali
+      - fastlane build flavor:ebpp_indonesia
+      - fastlane build flavor:hope_through_health
+    - script:
+      - fastlane build flavor:livinggoods
+      - fastlane build flavor:livinggoodskenya
+      - fastlane build flavor:livinggoods_assisted_networks
+    - script:
+      - fastlane build flavor:livinggoods_innovation_ke
+      - fastlane build flavor:livinggoods_innovation_ke_supervisor
+      - fastlane build flavor:livinggoods_innovation_ke_hivst
+    - script:
+#     - fastlane build flavor:moh_kenya_siaya_white
+      - fastlane build flavor:moh_kenya_siaya_red
+      - fastlane build flavor:moh_kenya_siaya_green
+      - fastlane build flavor:moh_kenya_siaya_black
+      - fastlane build flavor:moh_mali
+    - script:
+      - fastlane build flavor:moh_zanzibar_training
+      - fastlane build flavor:moh_zanzibar
+    - script:
+      - fastlane build flavor:musomali
+      - fastlane build flavor:pih_malawi
+      - fastlane build flavor:pih_malawi_supervisor
+    - script:
+      - fastlane build flavor:simprints
+      - fastlane build flavor:surveillance_covid19_kenya
+      - fastlane build flavor:vhw_burundi
+    - script:
 before_install:
 - openssl aes-256-cbc -K $encrypted_323c4a109760_key -iv $encrypted_323c4a109760_iv -in secrets.tar.gz.enc -out ./secrets.tar.gz -d
 - tar -xf ./secrets.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ stages:
   - name: test
   - name: alpha
     if: tag =~ ^v.+-alpha\.[0-9]+$ # eg: v3.6.0-alpha.1
-  - name: deploy
+  - name: final
     if: tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ # eg: v3.6.0
 jobs:
   include:
@@ -22,48 +22,48 @@ jobs:
       script: make test
 
     - stage: alpha
-      script: fastlane deploy flavor:unbranded
-      script: fastlane deploy flavor:medicmobilegamma
-      script: fastlane deploy flavor:covid_moh_mali
+      script: fastlane build flavor:unbranded
+      script: fastlane build flavor:medicmobilegamma
+      script: fastlane build flavor:medicmobiledemo
   
-    - stage: deploy
-      script: fastlane deploy flavor:unbranded
-      script: fastlane deploy flavor:medicmobilegamma
-      script: fastlane deploy flavor:medicmobiledemo
-
-#    - script:
-#      - fastlane deploy flavor:bracuganda
-#      - fastlane deploy flavor:cic_guatemala
-#    - script:
-#      - fastlane deploy flavor:cmmb_kenya
-#      - fastlane deploy flavor:ebpp_indonesia
-#      - fastlane deploy flavor:hope_through_health
-#    - script:
-#      - fastlane deploy flavor:livinggoods
-#      - fastlane deploy flavor:livinggoodskenya
-#      - fastlane deploy flavor:livinggoods_assisted_networks
-#    - script:
-#      - fastlane deploy flavor:livinggoods_innovation_ke
-#      - fastlane deploy flavor:livinggoods_innovation_ke_supervisor
-#      - fastlane deploy flavor:livinggoods_innovation_ke_hivst
-#    - script:
-#      - fastlane deploy flavor:moh_kenya_siaya_white
-#      - fastlane deploy flavor:moh_kenya_siaya_red
-#      - fastlane deploy flavor:moh_kenya_siaya_green
-#      - fastlane deploy flavor:moh_kenya_siaya_black
-#      - fastlane deploy flavor:moh_mali
-#    - script:
-#      - fastlane deploy flavor:moh_zanzibar_training
-#      - fastlane deploy flavor:moh_zanzibar
-#    - script:
-#      - fastlane deploy flavor:musomali
-#      - fastlane deploy flavor:pih_malawi
-#      - fastlane deploy flavor:pih_malawi_supervisor
-#    - script:
-#      - fastlane deploy flavor:simprints
-#      - fastlane deploy flavor:surveillance_covid19_kenya
-#      - fastlane deploy flavor:vhw_burundi
-    
+    - stage: final
+    - script:
+      - fastlane build flavor:unbranded
+      - fastlane build flavor:medicmobilegamma
+      - fastlane build flavor:medicmobiledemo
+    - script:
+      - fastlane build flavor:bracuganda
+      - fastlane build flavor:cic_guatemala
+      - fastlane build flavor:cmmb_kenya
+    - script:
+      - fastlane build flavor:covid_moh_mali
+      - fastlane build flavor:ebpp_indonesia
+      - fastlane build flavor:hope_through_health
+    - script:
+      - fastlane build flavor:livinggoods
+      - fastlane build flavor:livinggoodskenya
+      - fastlane build flavor:livinggoods_assisted_networks
+    - script:
+      - fastlane build flavor:livinggoods_innovation_ke
+      - fastlane build flavor:livinggoods_innovation_ke_supervisor
+      - fastlane build flavor:livinggoods_innovation_ke_hivst
+    - script:
+#     - fastlane build flavor:moh_kenya_siaya_white
+      - fastlane build flavor:moh_kenya_siaya_red
+      - fastlane build flavor:moh_kenya_siaya_green
+      - fastlane build flavor:moh_kenya_siaya_black
+      - fastlane build flavor:moh_mali
+    - script:
+      - fastlane build flavor:moh_zanzibar_training
+      - fastlane build flavor:moh_zanzibar
+    - script:
+      - fastlane build flavor:musomali
+      - fastlane build flavor:pih_malawi
+      - fastlane build flavor:pih_malawi_supervisor
+    - script:
+      - fastlane build flavor:simprints
+      - fastlane build flavor:surveillance_covid19_kenya
+      - fastlane build flavor:vhw_burundi
 before_install:
 - openssl aes-256-cbc -K $encrypted_323c4a109760_key -iv $encrypted_323c4a109760_iv -in secrets.tar.gz.enc -out ./secrets.tar.gz -d
 - tar -xf ./secrets.tar.gz
@@ -78,14 +78,21 @@ cache:
   - "$HOME/.gradle/wrapper/"
   - "$HOME/.android/build-cache"
 deploy:
-  provider: releases
-  skip_cleanup: true
-  overwrite: true
-  api_key:
-    secure: Dm6ciqGeR3zT+/hdO4jq+2sMa/d3sHSQ1U9ya9tCu71+BMZfjRA8vgBAWgnp6xixCUTEppJNgRrKaCR9V12Yu8Yl3ceY3bGRd6xhR9uUK+PgFUSjptuiwgwE1Fbj7lxT1NG1ZptvnqYZ0YhPiAC5cmcJUuz/0g83fKJfDNrX9V6IGQObdiPqDJX3cVbU/5NpSbIsnNqQfaldMP2Y1m1gODMCifOqM2Mj1nHd+X9OzEpuICCZiiHJJBKafdifZKmPlSgYDjt3d6DCsn5YiNnNm5Rs4kqWJc4YvV2G+S4eMnL7XB4pg45zZQ6ZIwn3NPp5a4pfHTn5nGC/2Hqqe8cw+xURYf/qrOZp3mQgAYiJht9bivMhwlvCvTh2kw+xorTj7wlFDSyj78QLxjxidiAj0AkBdYlVttSXDXAoCTGKHDhFEtKNviVdB9TNfYwKTFin4BCPsPnBEQZB9pzqIwBha9INjutYUJ9aX1uC7a1grR7Oa6IL7NH0Z0sV7bYkoW91X0ZxQtsVnFduc2y6AwKzqlO1VKN0U55KmUnj0STCGSMHZoI1cObBJtCzUcUnH7NIEfeZLq/tQ8sRkFlCJ1g2bJI0VG8DMTP56krvHKNknLacN5SjloNCST3SL6qlYto95ypSlfU+u3qpC6kNdXa7Yvodk+5u7VVQcX18xczbYvs=
-  file_glob: true
-  file: ./build/outputs/apk/**/*.apk
-  on:
-    tags: true
-    repo: medic/medic-android
-    branch: master
+  - provider: releases
+    skip_cleanup: true
+    overwrite: true
+    api_key:
+      secure: Dm6ciqGeR3zT+/hdO4jq+2sMa/d3sHSQ1U9ya9tCu71+BMZfjRA8vgBAWgnp6xixCUTEppJNgRrKaCR9V12Yu8Yl3ceY3bGRd6xhR9uUK+PgFUSjptuiwgwE1Fbj7lxT1NG1ZptvnqYZ0YhPiAC5cmcJUuz/0g83fKJfDNrX9V6IGQObdiPqDJX3cVbU/5NpSbIsnNqQfaldMP2Y1m1gODMCifOqM2Mj1nHd+X9OzEpuICCZiiHJJBKafdifZKmPlSgYDjt3d6DCsn5YiNnNm5Rs4kqWJc4YvV2G+S4eMnL7XB4pg45zZQ6ZIwn3NPp5a4pfHTn5nGC/2Hqqe8cw+xURYf/qrOZp3mQgAYiJht9bivMhwlvCvTh2kw+xorTj7wlFDSyj78QLxjxidiAj0AkBdYlVttSXDXAoCTGKHDhFEtKNviVdB9TNfYwKTFin4BCPsPnBEQZB9pzqIwBha9INjutYUJ9aX1uC7a1grR7Oa6IL7NH0Z0sV7bYkoW91X0ZxQtsVnFduc2y6AwKzqlO1VKN0U55KmUnj0STCGSMHZoI1cObBJtCzUcUnH7NIEfeZLq/tQ8sRkFlCJ1g2bJI0VG8DMTP56krvHKNknLacN5SjloNCST3SL6qlYto95ypSlfU+u3qpC6kNdXa7Yvodk+5u7VVQcX18xczbYvs=
+    file_glob: true
+    file: ./build/outputs/apk/**/*.apk
+    on:
+      tags: true
+      repo: medic/medic-android
+      branch: master
+  - provider: script
+    script: fastlane deploy flavor:unbranded && fastlane deploy flavor:medicmobilegamma && fastlane deploy flavor:medicmobiledemo
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: medic/medic-android
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,43 +27,42 @@ jobs:
       script: fastlane build flavor:medicmobiledemo
   
     - stage: final
-    - script:
-      - fastlane build flavor:unbranded
-      - fastlane build flavor:medicmobilegamma
-      - fastlane build flavor:medicmobiledemo
-    - script:
-      - fastlane build flavor:bracuganda
-      - fastlane build flavor:cic_guatemala
-      - fastlane build flavor:cmmb_kenya
-    - script:
-      - fastlane build flavor:covid_moh_mali
-      - fastlane build flavor:ebpp_indonesia
-      - fastlane build flavor:hope_through_health
-    - script:
-      - fastlane build flavor:livinggoods
-      - fastlane build flavor:livinggoodskenya
-      - fastlane build flavor:livinggoods_assisted_networks
-    - script:
-      - fastlane build flavor:livinggoods_innovation_ke
-      - fastlane build flavor:livinggoods_innovation_ke_supervisor
-      - fastlane build flavor:livinggoods_innovation_ke_hivst
-    - script:
-#     - fastlane build flavor:moh_kenya_siaya_white
-      - fastlane build flavor:moh_kenya_siaya_red
-      - fastlane build flavor:moh_kenya_siaya_green
-      - fastlane build flavor:moh_kenya_siaya_black
-      - fastlane build flavor:moh_mali
-    - script:
-      - fastlane build flavor:moh_zanzibar_training
-      - fastlane build flavor:moh_zanzibar
-    - script:
-      - fastlane build flavor:musomali
-      - fastlane build flavor:pih_malawi
-      - fastlane build flavor:pih_malawi_supervisor
-    - script:
-      - fastlane build flavor:simprints
-      - fastlane build flavor:surveillance_covid19_kenya
-      - fastlane build flavor:vhw_burundi
+      - script:
+        - fastlane build flavor:unbranded
+        - fastlane build flavor:medicmobilegamma
+        - fastlane build flavor:medicmobiledemo
+      - script:
+        - fastlane build flavor:bracuganda
+        - fastlane build flavor:cic_guatemala
+      - script:
+        - fastlane build flavor:cmmb_kenya
+        - fastlane build flavor:ebpp_indonesia
+        - fastlane build flavor:hope_through_health
+      - script:
+        - fastlane build flavor:livinggoods
+        - fastlane build flavor:livinggoodskenya
+        - fastlane build flavor:livinggoods_assisted_networks
+      - script:
+        - fastlane build flavor:livinggoods_innovation_ke
+        - fastlane build flavor:livinggoods_innovation_ke_supervisor
+        - fastlane build flavor:livinggoods_innovation_ke_hivst
+      - script:
+  #     - fastlane build flavor:moh_kenya_siaya_white
+        - fastlane build flavor:moh_kenya_siaya_red
+        - fastlane build flavor:moh_kenya_siaya_green
+        - fastlane build flavor:moh_kenya_siaya_black
+        - fastlane build flavor:moh_mali
+      - script:
+        - fastlane build flavor:moh_zanzibar_training
+        - fastlane build flavor:moh_zanzibar
+      - script:
+        - fastlane build flavor:musomali
+        - fastlane build flavor:pih_malawi
+        - fastlane build flavor:pih_malawi_supervisor
+      - script:
+        - fastlane build flavor:simprints
+        - fastlane build flavor:surveillance_covid19_kenya
+        - fastlane build flavor:vhw_burundi
 before_install:
 - openssl aes-256-cbc -K $encrypted_323c4a109760_key -iv $encrypted_323c4a109760_iv -in secrets.tar.gz.enc -out ./secrets.tar.gz -d
 - tar -xf ./secrets.tar.gz

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,13 +5,14 @@
 default_platform(:android)
 
 platform :android do
-  desc "Build and deploy on Google Play"
+  lane :build do |options|
+    gradle(task: "assemble#{options[:flavor]}WebviewRelease")
+    gradle(task: "assemble#{options[:flavor]}XwalkRelease")
+  end
+
   lane :deploy do |options|
     version = ENV['TRAVIS_TAG'].empty? ? 'SNAPSHOT' : ENV['TRAVIS_TAG']
     package_name = options[:flavor] == 'unbranded' ? "org.medicmobile.webapp.mobile" : "org.medicmobile.webapp.mobile.#{options[:flavor]}"
-
-    gradle(task: "assemble#{options[:flavor]}WebviewRelease")
-    gradle(task: "assemble#{options[:flavor]}XwalkRelease")
 
     supply(
       package_name: package_name,


### PR DESCRIPTION
This means we can build all apks, and publish to GitHub, without
also publishing to the Play Store.

medic/medic-android#138

Also solves a bug where Play Store rejection meant the apks weren't
uploaded to GitHub by switching the order of release steps.

medic/medic-android#91