### PR TITLE
Avoid result code collisions

### DIFF
--- a/src/main/java/org/medicmobile/webapp/mobile/MrdtSupport.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/MrdtSupport.java
@@ -6,7 +6,7 @@ import android.util.Base64;
 
 //import org.json.JSONException;
 
-import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_MRDT_PHOTO;
+import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE;
 import static org.medicmobile.webapp.mobile.JavascriptUtils.safeFormat;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.MedicLog.warn;
@@ -26,14 +26,14 @@ class MrdtSupport {
 	}
 
 	void startVerify() {
-		ctx.startActivityForResult(verifyIntent(), GRAB_MRDT_PHOTO);
+		ctx.startActivityForResult(verifyIntent(), GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE);
 	}
 
 	String process(int requestCode, int resultCode, Intent i) {
 		trace(this, "process() :: requestCode=%s", requestCode);
 
 		switch(requestCode) {
-			case GRAB_MRDT_PHOTO: {
+			case GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE: {
 				try {
 					byte[] data = i.getByteArrayExtra("data");
 					String base64data = Base64.encodeToString(data, Base64.NO_WRAP);

--- a/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -49,12 +49,12 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	 * bitmask is used to respect the scheme on that side of things.
 	 * */
 	private static final int NON_SIMPRINTS_FLAGS = 0x7;
-	static final int GRAB_PHOTO = (0 << 3) | NON_SIMPRINTS_FLAGS;
-	static final int GRAB_MRDT_PHOTO = (1 << 3) | NON_SIMPRINTS_FLAGS;
-	static final int DISCLOSURE_LOCATION_PERMISSION_REQUEST = (2 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int GRAB_PHOTO_ACTIVITY_REQUEST_CODE = (0 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE = (1 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE = (2 << 3) | NON_SIMPRINTS_FLAGS;
 
 	// Arbitrarily selected value
-	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST = 7038678;
+	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE = 7038678;
 
 	private static final String[] LOCATION_PERMISSIONS = { Manifest.permission.ACCESS_FINE_LOCATION };
 
@@ -181,15 +181,15 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 					requestCodeToString(requestCode), resultCode);
 			if((requestCode & NON_SIMPRINTS_FLAGS) == NON_SIMPRINTS_FLAGS) {
 				switch(requestCode) {
-					case GRAB_PHOTO:
+					case GRAB_PHOTO_ACTIVITY_REQUEST_CODE:
 						photoGrabber.process(requestCode, resultCode, i);
 						return;
-					case GRAB_MRDT_PHOTO:
+					case GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE:
 						String js = mrdt.process(requestCode, resultCode, i);
 						trace(this, "Execing JS: %s", js);
 						evaluateJavascript(js);
 						return;
-					case DISCLOSURE_LOCATION_PERMISSION_REQUEST:
+					case DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE:
 						// User accepted or denied to allow the app to access
 						// location data in RequestPermissionActivity
 						if (resultCode == RESULT_OK) {                    // user accepted
@@ -197,7 +197,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 							ActivityCompat.requestPermissions(
 									this,
 									LOCATION_PERMISSIONS,
-									ACCESS_FINE_LOCATION_PERMISSION_REQUEST);
+									ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE);
 						} else if (resultCode == RESULT_CANCELED) {        // user rejected
 							try {
 								this.locationRequestResolved();
@@ -224,11 +224,11 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	}
 
 	private String requestCodeToString(int requestCode) {
-		if (requestCode == ACCESS_FINE_LOCATION_PERMISSION_REQUEST) {
-			return "ACCESS_FINE_LOCATION_PERMISSION_REQUEST";
+		if (requestCode == ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE) {
+			return "ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE";
 		}
-		if (requestCode == DISCLOSURE_LOCATION_PERMISSION_REQUEST) {
-			return "DISCLOSURE_LOCATION_PERMISSION_REQUEST";
+		if (requestCode == DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE) {
+			return "DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE";
 		}
 		return String.valueOf(requestCode);
 	}
@@ -358,14 +358,14 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 		trace(this, "getLocationPermissions() :: location not granted before, requesting access...");
 		startActivityForResult(
 				new Intent(this, RequestPermissionActivity.class),
-				DISCLOSURE_LOCATION_PERMISSION_REQUEST);
+				DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE);
 		return false;
 	}
 
 	@Override
 	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
 		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-		if (requestCode != ACCESS_FINE_LOCATION_PERMISSION_REQUEST) {
+		if (requestCode != ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE) {
 			return;
 		}
 		locationRequestResolved();

--- a/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -40,15 +40,21 @@ import static org.medicmobile.webapp.mobile.Utils.isUrlRelated;
 
 @SuppressWarnings({ "PMD.GodClass", "PMD.TooManyMethods" })
 public class EmbeddedBrowserActivity extends LockableActivity {
-	/** Any activity result with all 3 low bits set is _not_ a simprints result. */
+	/**
+	 * Any activity result with all 3 low bits set is _not_ a simprints result.
+	 *
+	 * The following block of bit-shifted integers are intended for use in the subsystem seen
+	 * in the onActivityResult below. These integers respect the reserved block of integers
+	 * which are used by simprints. Simprint intents are started in the webapp where a matching
+	 * bitmask is used to respect the scheme on that side of things.
+	 * */
 	private static final int NON_SIMPRINTS_FLAGS = 0x7;
 	static final int GRAB_PHOTO = (0 << 3) | NON_SIMPRINTS_FLAGS;
 	static final int GRAB_MRDT_PHOTO = (1 << 3) | NON_SIMPRINTS_FLAGS;
-	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST = (int)(Math.random() * 1000);
+	static final int DISCLOSURE_LOCATION_PERMISSION_REQUEST = (2 << 3) | NON_SIMPRINTS_FLAGS;
 
-	// Use different ranges of random values for other request codes caught by the same method,
-	// eg. (int)(Math.random() * 1000) + 1000
-	private static final int DISCLOSURE_LOCATION_PERMISSION_REQUEST = (int)(Math.random() * 1000);
+	// Arbitrarily selected value
+	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST = 7038678;
 
 	private static final String[] LOCATION_PERMISSIONS = { Manifest.permission.ACCESS_FINE_LOCATION };
 
@@ -183,26 +189,27 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 						trace(this, "Execing JS: %s", js);
 						evaluateJavascript(js);
 						return;
+					case DISCLOSURE_LOCATION_PERMISSION_REQUEST:
+						// User accepted or denied to allow the app to access
+						// location data in RequestPermissionActivity
+						if (resultCode == RESULT_OK) {                    // user accepted
+							// Request to Android location data access
+							ActivityCompat.requestPermissions(
+									this,
+									LOCATION_PERMISSIONS,
+									ACCESS_FINE_LOCATION_PERMISSION_REQUEST);
+						} else if (resultCode == RESULT_CANCELED) {        // user rejected
+							try {
+								this.locationRequestResolved();
+								settings.setUserDeniedGeolocation();
+							} catch (SettingsException e) {
+								error(e, "Error recording negative to access location");
+							}
+						}
+						return;
 					default:
 						trace(this, "onActivityResult() :: no handling for requestCode=%s",
 								requestCodeToString(requestCode));
-				}
-			} else if(requestCode == DISCLOSURE_LOCATION_PERMISSION_REQUEST) {
-				// User accepted or denied to allow the app to access
-				// location data in RequestPermissionActivity
-				if (resultCode == RESULT_OK) {					// user accepted
-					// Request to Android location data access
-					ActivityCompat.requestPermissions(
-							this,
-							LOCATION_PERMISSIONS,
-							ACCESS_FINE_LOCATION_PERMISSION_REQUEST);
-				} else if (resultCode == RESULT_CANCELED) {		// user rejected
-					try {
-						this.locationRequestResolved();
-						settings.setUserDeniedGeolocation();
-					} catch (SettingsException e) {
-						error(e, "Error recording negative to access location");
-					}
 				}
 			} else {
 				String js = simprints.process(requestCode, i);

--- a/src/webview/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
@@ -17,7 +17,7 @@ import static android.app.Activity.RESULT_OK;
 import static android.provider.MediaStore.ACTION_IMAGE_CAPTURE;
 import static com.mvc.imagepicker.ImagePicker.getImageFromResult;
 import static com.mvc.imagepicker.ImagePicker.getPickImageIntent;
-import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_PHOTO;
+import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_PHOTO_ACTIVITY_REQUEST_CODE;
 import static org.medicmobile.webapp.mobile.MedicLog.log;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.MedicLog.warn;
@@ -112,14 +112,14 @@ class PhotoGrabber {
 	}
 
 	private void takePhoto() {
-		a.startActivityForResult(cameraIntent(), GRAB_PHOTO);
+		a.startActivityForResult(cameraIntent(), GRAB_PHOTO_ACTIVITY_REQUEST_CODE);
 	}
 
 	private void pickImage() {
 		trace(this, "picking image intent");
 		Intent i = getPickImageIntent(a, a.getString(R.string.promptChooseImage));
 		trace(this, "starting activity :: %s", i);
-		a.startActivityForResult(i, GRAB_PHOTO);
+		a.startActivityForResult(i, GRAB_PHOTO_ACTIVITY_REQUEST_CODE);
 	}
 
 	private boolean canStartCamera() {

--- a/src/xwalk/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/xwalk/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -53,12 +53,12 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	 * bitmask is used to respect the scheme on that side of things.
 	 * */
 	private static final int NON_SIMPRINTS_FLAGS = 0x7;
-	static final int GRAB_PHOTO = (0 << 3) | NON_SIMPRINTS_FLAGS;
-	static final int GRAB_MRDT_PHOTO = (1 << 3) | NON_SIMPRINTS_FLAGS;
-	static final int DISCLOSURE_LOCATION_PERMISSION_REQUEST = (2 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int GRAB_PHOTO_ACTIVITY_REQUEST_CODE = (0 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE = (1 << 3) | NON_SIMPRINTS_FLAGS;
+	static final int DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE = (2 << 3) | NON_SIMPRINTS_FLAGS;
 
 	// Arbitrarily selected value
-	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST = 7038678; // Arbitrarily selected value
+	private static final int ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE = 7038678; // Arbitrarily selected value
 
 	private static final String[] LOCATION_PERMISSIONS = { Manifest.permission.ACCESS_FINE_LOCATION };
 
@@ -187,15 +187,15 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 					requestCodeToString(requestCode), resultCode);
 			if((requestCode & NON_SIMPRINTS_FLAGS) == NON_SIMPRINTS_FLAGS) {
 				switch(requestCode) {
-					case GRAB_PHOTO:
+					case GRAB_PHOTO_ACTIVITY_REQUEST_CODE:
 						photoGrabber.process(requestCode, resultCode, i);
 						return;
-					case GRAB_MRDT_PHOTO:
+					case GRAB_MRDT_PHOTO_ACTIVITY_REQUEST_CODE:
 						String js = mrdt.process(requestCode, resultCode, i);
 						trace(this, "Execing JS: %s", js);
 						evaluateJavascript(js);
 						return;
-					case DISCLOSURE_LOCATION_PERMISSION_REQUEST:
+					case DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE:
 						// User accepted or denied to allow the app to access
 						// location data in RequestPermissionActivity
 						if (resultCode == RESULT_OK) {                    // user accepted
@@ -203,7 +203,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 							ActivityCompat.requestPermissions(
 									this,
 									LOCATION_PERMISSIONS,
-									ACCESS_FINE_LOCATION_PERMISSION_REQUEST);
+									ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE);
 						} else if (resultCode == RESULT_CANCELED) {        // user rejected
 							try {
 								this.locationRequestResolved();
@@ -230,11 +230,11 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 	}
 
 	private String requestCodeToString(int requestCode) {
-		if (requestCode == ACCESS_FINE_LOCATION_PERMISSION_REQUEST) {
-			return "ACCESS_FINE_LOCATION_PERMISSION_REQUEST";
+		if (requestCode == ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE) {
+			return "ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE";
 		}
-		if (requestCode == DISCLOSURE_LOCATION_PERMISSION_REQUEST) {
-			return "DISCLOSURE_LOCATION_PERMISSION_REQUEST";
+		if (requestCode == DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE) {
+			return "DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE";
 		}
 		return String.valueOf(requestCode);
 	}
@@ -377,13 +377,13 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 		trace(this, "getLocationPermissions() :: location not granted before, requesting access...");
 		startActivityForResult(
 				new Intent(this, RequestPermissionActivity.class),
-				DISCLOSURE_LOCATION_PERMISSION_REQUEST);
+				DISCLOSURE_LOCATION_ACTIVITY_REQUEST_CODE);
 		return false;
 	}
 
 	@Override
 	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-		if (requestCode != ACCESS_FINE_LOCATION_PERMISSION_REQUEST) {
+		if (requestCode != ACCESS_FINE_LOCATION_PERMISSION_REQUEST_CODE) {
 			return;
 		}
 		locationRequestResolved();

--- a/src/xwalk/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
+++ b/src/xwalk/java/org/medicmobile/webapp/mobile/PhotoGrabber.java
@@ -17,7 +17,7 @@ import static android.app.Activity.RESULT_OK;
 import static android.provider.MediaStore.ACTION_IMAGE_CAPTURE;
 import static com.mvc.imagepicker.ImagePicker.getImageFromResult;
 import static com.mvc.imagepicker.ImagePicker.getPickImageIntent;
-import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_PHOTO;
+import static org.medicmobile.webapp.mobile.EmbeddedBrowserActivity.GRAB_PHOTO_ACTIVITY_REQUEST_CODE;
 import static org.medicmobile.webapp.mobile.MedicLog.log;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.MedicLog.warn;
@@ -105,12 +105,12 @@ class PhotoGrabber {
 	}
 
 	private void takePhoto() {
-		a.startActivityForResult(cameraIntent(), GRAB_PHOTO);
+		a.startActivityForResult(cameraIntent(), GRAB_PHOTO_ACTIVITY_REQUEST_CODE);
 	}
 
 	private void pickImage() {
 		Intent i = getPickImageIntent(a, a.getString(R.string.promptChooseImage));
-		a.startActivityForResult(i, GRAB_PHOTO);
+		a.startActivityForResult(i, GRAB_PHOTO_ACTIVITY_REQUEST_CODE);
 	}
 
 	private boolean canStartCamera() {


### PR DESCRIPTION
The new code to handle the location permissions risked colliding with the scheme used for handling simprints result codes. This change sets the new result code to a constant in the reserved space.

The prior version also used random numbers, which is removed as a side effect of this specific code selection.

This should address the intermittent issues we have seen during testing, which I believe were a result of the new intent returning and having the undesired effect of being handled by the photo-grabbing handler code.