### PR TITLE
Rollback image picker update that causes app to crash when clicking upload component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ android {
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.simprints:LibSimprints:1.0.11'
-  implementation 'com.github.Mariovc:ImagePicker:1.2.2'
+  implementation 'com.github.Mariovc:ImagePicker:1.2.0'
   xwalkImplementation files('src/xwalk/libs/xwalk_core_library-23.53.589.4-arm64-v8a.aar')
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.google.android:android-test:4.1.1.4'


### PR DESCRIPTION
Downgrade `com.github.Mariovc:ImagePicker` library ~1.2.2~ → 1.2.0 as it was before when working, to allow user to use the file chooser again.

Issue: #127 

### Notes

- The [ImagePicker library](https://github.com/Mariovc/ImagePicker) was updated from the version 1.2.0 to 1.2.2 two years ago on this commit: https://github.com/medic/medic-android/commit/7538d16b0097b233cffc23ea19feac88e9a201c0 2 years ago, for sure it worked for some devices or older versions of Android :man_shrugging: on that moment. In fact the older version set again didn't work with a virtual Android 10 device, but it worked in my Android 10 and Android 11 devices (Webview flavor). I also tested it with an Android 6 device (XWalk) and it worked with the v1.2.0 set again. But we should test it with more devices and OS versions, like Android 4.4 if we continue supporting it.
- The last version of the library is the one that was set (1.2.2), and the project don't have a newer version since 2018, and in 2019 was officially deprecated by the author, so maybe it is a good time to replace it with a more up-to-date library.
- The author suggest a good [replacement](https://developer.android.com/training/camerax) that it is also officially recommended by Google, but it supports Android 5 and above, so if we want to keep supporting Android 4.4 is not an option. Although I'm not sure yet wheter this replacement also allows to pick images from local storage or only supports the camera, in which case is also not a good fit.
