### PR TITLE
163 - Improve connection errors UX (Webview)

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -42,13 +42,18 @@
     <activity android:name="UpgradingActivity"
         android:screenOrientation="portrait"
         android:configChanges="orientation|screenSize"/>
+    <activity android:name="ConnectionErrorActivity"
+        android:screenOrientation="portrait"
+        android:configChanges="orientation|screenSize"
+        android:launchMode="singleTop"/>
     <activity android:name="FreeSpaceWarningActivity"
         android:screenOrientation="portrait"/>
     <activity android:name="SettingsDialogActivity"
         android:screenOrientation="portrait"/>
     <activity android:name="RequestPermissionActivity"
         android:screenOrientation="portrait"/>
-    <activity android:name="AppUrlIntentActivity" android:launchMode="singleInstance">
+    <activity android:name="AppUrlIntentActivity"
+        android:launchMode="singleInstance">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -41,7 +41,8 @@
         android:configChanges="orientation|screenSize"/>
     <activity android:name="UpgradingActivity"
         android:screenOrientation="portrait"
-        android:configChanges="orientation|screenSize"/>
+        android:configChanges="orientation|screenSize"
+        android:launchMode="singleTop"/>
     <activity android:name="ConnectionErrorActivity"
         android:screenOrientation="portrait"
         android:configChanges="orientation|screenSize"

--- a/src/main/java/org/medicmobile/webapp/mobile/AlertDialogUtils.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/AlertDialogUtils.java
@@ -1,0 +1,41 @@
+package org.medicmobile.webapp.mobile;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+
+public abstract class AlertDialogUtils {
+
+	/**
+	 * Display a simple dialog window with a title, a message, and
+	 * and a "OK" button.
+	 */
+	public static void show(
+			Context context,
+			String title,
+			String message
+	) {
+		show(context, title, message, context.getResources().getString(R.string.btnOk));
+	}
+
+	/**
+	 * Display a simple dialog window with a title, a message, and
+	 * and a confirmation button.
+	 */
+	public static void show(
+		Context context,
+		String title,
+		String message,
+		String okLabel
+	) {
+		new AlertDialog.Builder(context)
+			.setTitle(title)
+			.setMessage(message)
+			.setNeutralButton(okLabel, new DialogInterface.OnClickListener() {
+				@Override public void onClick(DialogInterface dialog, int which) {
+					dialog.dismiss();
+				}
+			})
+			.create().show();
+	}
+}

--- a/src/main/java/org/medicmobile/webapp/mobile/ClosableAppActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/ClosableAppActivity.java
@@ -3,75 +3,46 @@ package org.medicmobile.webapp.mobile;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.widget.Toast;
 
 /**
  * Base class for activities that when back is pressed
- * two times the app closes.
+ * it closes the app instead of move backward through
+ * the history of screens, or prevent the user to either
+ * close or go back in the activities stack.
  *
- * When the user press back for the first time, a message
- * defined in the `R.string.backToExit` string is shown
- * explaining that it has to press back one more time. The
- * message can be customized in the intent with the extended
- * data "backPressedMessage"
- * (calling `intent.putExtra("backPressedMessage", "...")`).
+ * By default when the user press back the app is exited.
  *
- * Also the opposite action can be configured: the app
+ * The opposite action can be configured: the app
  * not closing nor the activity when the user press
  * back one or more times: to do so the `Intent` used to launch
  * the activity needs to be set with the extended data "isClosable"
  * to `false` (calling `intent.putExtra("isClosable", false)`).
  * No message is shown to the user when back is pressed unless
  * the extended data "backPressedMessage" is also set with the
- * desired message.
+ * desired message string.
  */
 public abstract class ClosableAppActivity extends Activity {
 
-	private static final int WAIT_MILLIS = 2 * 1000;    // Back need to be pressed 2 times before this time
-
-	private boolean closeableApp = true;                // if true, back pressing 2 times close the app
-	private boolean backToExitPressedOnce = false;      // whether back was pressed the last WAIT_MILLIS
-	private String backPressedMessage = null;			// Customized message to show when back is pressed
+	private boolean isClosable = true;			// if true, back pressing close the app
+	private String backPressedMessage = null;	// Customized message to show when back is pressed
+												// and the app activity is not closable
 
 	@Override public void onBackPressed() {
-		if (closeableApp) {
-			if (backToExitPressedOnce) {
-				finishAffinity();
-				return;
-			}
-			backToExitPressedOnce = true;
-
-			toastMessage();
-
-			new Handler().postDelayed(new Runnable() {
-				@Override public void run() {
-					// After WAIT_MILLIS clean the back pressed history
-					backToExitPressedOnce = false;
-				}
-			}, WAIT_MILLIS);
+		if (isClosable) {
+			finishAffinity();
 		} else {
 			// Back pressed events won't close the app nor close the activity
-			toastMessage();
+			if (backPressedMessage != null) {
+				Toast.makeText(this, backPressedMessage, Toast.LENGTH_SHORT).show();
+			}
 		}
 	}
 
 	@Override public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		Intent i = getIntent();
-		closeableApp = i.getBooleanExtra("isClosable", true);	// not closable (the default value is true)
-		backPressedMessage = i.getStringExtra("backPressedMessage");	// default null
-	}
-
-	private void toastMessage() {
-		if (closeableApp) {
-			if (backPressedMessage != null) {
-				Toast.makeText(this, backPressedMessage, Toast.LENGTH_SHORT).show();
-			} else {
-				Toast.makeText(this, R.string.backToExit, Toast.LENGTH_SHORT).show();
-			}
-		} else if (backPressedMessage != null) {
-			Toast.makeText(this, backPressedMessage, Toast.LENGTH_SHORT).show();
-		}
+		isClosable = i.getBooleanExtra("isClosable", true);
+		backPressedMessage = i.getStringExtra("backPressedMessage");
 	}
 }

--- a/src/main/java/org/medicmobile/webapp/mobile/ClosableAppActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/ClosableAppActivity.java
@@ -1,0 +1,77 @@
+package org.medicmobile.webapp.mobile;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.widget.Toast;
+
+/**
+ * Base class for activities that when back is pressed
+ * two times the app closes.
+ *
+ * When the user press back for the first time, a message
+ * defined in the `R.string.backToExit` string is shown
+ * explaining that it has to press back one more time. The
+ * message can be customized in the intent with the extended
+ * data "backPressedMessage"
+ * (calling `intent.putExtra("backPressedMessage", "...")`).
+ *
+ * Also the opposite action can be configured: the app
+ * not closing nor the activity when the user press
+ * back one or more times: to do so the `Intent` used to launch
+ * the activity needs to be set with the extended data "isClosable"
+ * to `false` (calling `intent.putExtra("isClosable", false)`).
+ * No message is shown to the user when back is pressed unless
+ * the extended data "backPressedMessage" is also set with the
+ * desired message.
+ */
+public abstract class ClosableAppActivity extends Activity {
+
+	private static final int WAIT_MILLIS = 2 * 1000;    // Back need to be pressed 2 times before this time
+
+	private boolean closeableApp = true;                // if true, back pressing 2 times close the app
+	private boolean backToExitPressedOnce = false;      // whether back was pressed the last WAIT_MILLIS
+	private String backPressedMessage = null;			// Customized message to show when back is pressed
+
+	@Override public void onBackPressed() {
+		if (closeableApp) {
+			if (backToExitPressedOnce) {
+				finishAffinity();
+				return;
+			}
+			backToExitPressedOnce = true;
+
+			toastMessage();
+
+			new Handler().postDelayed(new Runnable() {
+				@Override public void run() {
+					// After WAIT_MILLIS clean the back pressed history
+					backToExitPressedOnce = false;
+				}
+			}, WAIT_MILLIS);
+		} else {
+			// Back pressed events won't close the app nor close the activity
+			toastMessage();
+		}
+	}
+
+	@Override public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		Intent i = getIntent();
+		closeableApp = i.getBooleanExtra("isClosable", true);	// not closable (the default value is true)
+		backPressedMessage = i.getStringExtra("backPressedMessage");	// default null
+	}
+
+	private void toastMessage() {
+		if (closeableApp) {
+			if (backPressedMessage != null) {
+				Toast.makeText(this, backPressedMessage, Toast.LENGTH_SHORT).show();
+			} else {
+				Toast.makeText(this, R.string.backToExit, Toast.LENGTH_SHORT).show();
+			}
+		} else if (backPressedMessage != null) {
+			Toast.makeText(this, backPressedMessage, Toast.LENGTH_SHORT).show();
+		}
+	}
+}

--- a/src/main/java/org/medicmobile/webapp/mobile/ConnectionErrorActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/ConnectionErrorActivity.java
@@ -1,0 +1,86 @@
+package org.medicmobile.webapp.mobile;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+
+import static android.view.View.VISIBLE;
+import static android.view.View.GONE;
+import static org.medicmobile.webapp.mobile.MedicLog.trace;
+
+
+/**
+ * Activity displayed to catch connection errors and give the user
+ * the chance to retry.
+ *
+ * NOTE: it only catch connection errors when the web container
+ * tries to load a new page or reload the current one.
+ * Errors when the webapp does ajax calls are caught by
+ * the webapp itself.
+ */
+public class ConnectionErrorActivity extends ClosableAppActivity {
+
+	@Override public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		this.requestWindowFeature(Window.FEATURE_NO_TITLE);
+		setContentView(R.layout.connection_error);
+
+		// If a page load finished and the activity is still spinning -> close
+		BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+			@Override public void onReceive(Context context, Intent intent) {
+				if ("onPageFinished".equals(intent.getAction()) && isSpinning()) {
+					unregisterReceiver(this);
+					finish();
+				}
+			}
+		};
+		registerReceiver(broadcastReceiver, new IntentFilter("onPageFinished"));
+	}
+
+	@Override protected void onNewIntent(Intent intent) {
+		showMessageLayout();
+	}
+
+	public void onClickRetry(View view) {
+		trace(this, "onClickRetry()");
+		sendBroadcast(new Intent("retryConnection"));
+		showSpinnerLayout();
+	}
+
+	// Toggle layout components: hide the message layout
+	// and display the spinner layout
+	private void showSpinnerLayout() {
+		setLayoutsVisibility(GONE, VISIBLE);
+	}
+
+	// Toggle layout components: hide the spinner layout
+	// and display the message layout
+	private void showMessageLayout() {
+		setLayoutsVisibility(VISIBLE, GONE);
+	}
+
+	// Set visibility for the Internet connection error layout
+	// and the spinner layout
+	private void setLayoutsVisibility(int messageLayoutVisibility, int spinnerVisibility) {
+		View messageLayout = getMessageLayout();
+		messageLayout.setVisibility(messageLayoutVisibility);
+		View spinnerLayout = getSpinnerLayout();
+		spinnerLayout.setVisibility(spinnerVisibility);
+	}
+
+	private View getMessageLayout() {
+		return findViewById(R.id.connErrorMessageLayout);
+	}
+
+	private View getSpinnerLayout() {
+		return findViewById(R.id.connErrorSpinnerLayout);
+	}
+
+	private boolean isSpinning() {
+		return getSpinnerLayout().getVisibility() == VISIBLE;
+	}
+}

--- a/src/main/java/org/medicmobile/webapp/mobile/ConnectionErrorActivity.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/ConnectionErrorActivity.java
@@ -24,6 +24,8 @@ import static org.medicmobile.webapp.mobile.MedicLog.trace;
  */
 public class ConnectionErrorActivity extends ClosableAppActivity {
 
+	String connErrorInfo;	// Error code and description
+
 	@Override public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		this.requestWindowFeature(Window.FEATURE_NO_TITLE);
@@ -39,16 +41,26 @@ public class ConnectionErrorActivity extends ClosableAppActivity {
 			}
 		};
 		registerReceiver(broadcastReceiver, new IntentFilter("onPageFinished"));
+
+		Intent i = getIntent();
+		connErrorInfo = i.getStringExtra("connErrorInfo");
 	}
 
 	@Override protected void onNewIntent(Intent intent) {
 		showMessageLayout();
 	}
 
+	// Retry connection
 	public void onClickRetry(View view) {
 		trace(this, "onClickRetry()");
 		sendBroadcast(new Intent("retryConnection"));
 		showSpinnerLayout();
+	}
+
+	// Show more info about the connection error
+	public void onClickMoreInfo(View view) {
+		trace(this, "onClickMoreInfo()");
+		AlertDialogUtils.show(this, getString(R.string.btnMoreInfo), connErrorInfo);
 	}
 
 	// Toggle layout components: hide the message layout

--- a/src/main/java/org/medicmobile/webapp/mobile/Utils.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/Utils.java
@@ -5,10 +5,12 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.webkit.WebResourceError;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import static android.webkit.WebViewClient.*;
 import static org.medicmobile.webapp.mobile.BuildConfig.APPLICATION_ID;
 import static org.medicmobile.webapp.mobile.BuildConfig.DEBUG;
 import static org.medicmobile.webapp.mobile.BuildConfig.VERSION_NAME;
@@ -76,5 +78,16 @@ final class Utils {
 		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 		context.startActivity(intent);
 		Runtime.getRuntime().exit(0);
+	}
+
+	static boolean isConnectionError(WebResourceError error) {
+		switch (error.getErrorCode()) {
+			case ERROR_HOST_LOOKUP:
+			case ERROR_PROXY_AUTHENTICATION:
+			case ERROR_CONNECT:
+			case ERROR_TIMEOUT:
+				return true;
+		}
+		return false;
 	}
 }

--- a/src/main/java/org/medicmobile/webapp/mobile/Utils.java
+++ b/src/main/java/org/medicmobile/webapp/mobile/Utils.java
@@ -90,4 +90,8 @@ final class Utils {
 		}
 		return false;
 	}
+
+	static String connectionErrorToString(WebResourceError error) {
+		return String.format("%s [%s]", error.getDescription(), error.getErrorCode());
+	}
 }

--- a/src/main/res/layout/connection_error.xml
+++ b/src/main/res/layout/connection_error.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
+
+
+    <RelativeLayout
+        android:id="@+id/connErrorMessageLayout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/connErrorTitleText"
+            style="@android:style/Widget.DeviceDefault.Light.TextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="140dp"
+            android:padding="20dp"
+            android:text="@string/connErrorTitle"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/connErrorMessageText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/connErrorTitleText"
+            android:padding="20dp"
+            android:text="@string/connErrorMessage"
+            android:textSize="18sp" />
+
+        <LinearLayout
+            android:id="@+id/connErrorButtons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/connErrorMessageText"
+            android:layout_marginTop="20dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:paddingBottom="20dp">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/connErrorRetry"
+                style="@style/Widget.AppCompat.Button.Borderless.Blue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onClickRetry"
+                android:text="@string/connErrorRetry" />
+        </LinearLayout>
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/connErrorSpinnerLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:id="@+id/progressBarIcon"
+            style="?android:attr/progressBarStyleLarge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:contentDescription="@string/loadingIconDescription"
+            android:padding="20dp" />
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/src/main/res/layout/connection_error.xml
+++ b/src/main/res/layout/connection_error.xml
@@ -43,6 +43,15 @@
             android:paddingRight="20dp"
             android:paddingBottom="20dp">
 
+            <Button
+                android:id="@+id/connErrorMoreInfo"
+                style="@style/Widget.AppCompat.Button.Borderless.Blue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onClickMoreInfo"
+                android:text="@string/btnMoreInfo"
+                android:textAllCaps="true" />
+
             <View
                 android:layout_width="0dp"
                 android:layout_height="0dp"
@@ -54,7 +63,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="onClickRetry"
-                android:text="@string/connErrorRetry" />
+                android:text="@string/btnRetry"
+                android:textAllCaps="true" />
         </LinearLayout>
     </RelativeLayout>
 

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="btnMoreInfo">Más info</string>
+	<string name="btnRetry">Reintentar</string>
+
 	<string name="locRequestTitle">Acceso a la ubicación</string>
 	<string name="locRequestMessage">%s recolecta información de la ubicación para analizar y mejorar resultados de salud en tu área. Para permitir el acceso a la ubicación selecciona \"Activar\", y luego confirma en el próximo diálogo.</string>
 	<string name="locRequestOkButton">Activar</string>
@@ -12,7 +15,6 @@
 
 	<string name="connErrorTitle">No hay Conexión a Internet</string>
 	<string name="connErrorMessage">Parece que no estás conectado a Internet. Por favor chequeá tu conexión y volvé a intentar.</string>
-	<string name="connErrorRetry">REINTENTAR</string>
 
 	<string name="waitMigration">Por favor espere a que el proceso de migración haya finalizado</string>
 </resources>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -14,6 +14,5 @@
 	<string name="connErrorMessage">Parece que no estás conectado a Internet. Por favor chequeá tu conexión y volvé a intentar.</string>
 	<string name="connErrorRetry">REINTENTAR</string>
 
-	<string name="backToExit">Por favor presione hacia atrás de nuevo para salir</string>
 	<string name="waitMigration">Por favor espere a que el proceso de migración haya finalizado</string>
 </resources>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -9,4 +9,11 @@
 	<string name="loadingIconDescription">Cargando…</string>
 	<string name="upgradingTitle">Actualizando la app</string>
 	<string name="upgradingMessage">Estás actualizando a la última versión. Por favor aguarda mientras tus datos son migrados.</string>
+
+	<string name="connErrorTitle">No hay Conexión a Internet</string>
+	<string name="connErrorMessage">Parece que no estás conectado a Internet. Por favor chequeá tu conexión y volvé a intentar.</string>
+	<string name="connErrorRetry">REINTENTAR</string>
+
+	<string name="backToExit">Por favor presione hacia atrás de nuevo para salir</string>
+	<string name="waitMigration">Por favor espere a que el proceso de migración haya finalizado</string>
 </resources>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -14,6 +14,5 @@
 	<string name="connErrorMessage">Vous n\'êtes pas bien connecté à internet. Veuillez vérifier votre connexion et réessayer.</string>
 	<string name="connErrorRetry">RÉESSAYER</string>
 
-	<string name="backToExit">Veuillez appuyer à nouveau pour quitter</string>
 	<string name="waitMigration">Veuillez attendre que la migration de données termine</string>
 </resources>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -9,4 +9,11 @@
 	<string name="loadingIconDescription">Chargement en cours…</string>
 	<string name="upgradingTitle">Mise à jour de votre application</string>
 	<string name="upgradingMessage">Vous passez à la nouvelle version. Veuillez patienter pendant la preparation de vos données.</string>
+
+	<string name="connErrorTitle">Pas de connexion Internet</string>
+	<string name="connErrorMessage">Vous ne semblez pas connecté à Internet. Veuillez vérifier votre connexion et réessayer.</string>
+	<string name="connErrorRetry">RECOMMENCEZ</string>
+
+	<string name="backToExit">Veuillez appuyer à nouveau pour quitter</string>
+	<string name="waitMigration">Veuillez attendre la fin du processus de migration</string>
 </resources>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -10,10 +10,10 @@
 	<string name="upgradingTitle">Mise à jour de votre application</string>
 	<string name="upgradingMessage">Vous passez à la nouvelle version. Veuillez patienter pendant la preparation de vos données.</string>
 
-	<string name="connErrorTitle">Pas de connexion Internet</string>
-	<string name="connErrorMessage">Vous ne semblez pas connecté à Internet. Veuillez vérifier votre connexion et réessayer.</string>
-	<string name="connErrorRetry">RECOMMENCEZ</string>
+	<string name="connErrorTitle">Aucune connexion Internet</string>
+	<string name="connErrorMessage">Vous n\'êtes pas bien connecté à internet. Veuillez vérifier votre connexion et réessayer.</string>
+	<string name="connErrorRetry">RÉESSAYER</string>
 
 	<string name="backToExit">Veuillez appuyer à nouveau pour quitter</string>
-	<string name="waitMigration">Veuillez attendre la fin du processus de migration</string>
+	<string name="waitMigration">Veuillez attendre que la migration de données termine</string>
 </resources>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="btnMoreInfo">Plus d\'information</string>
+	<string name="btnRetry">Réessayer</string>
+
 	<string name="locRequestTitle">Accès à la position</string>
 	<string name="locRequestMessage">%s collecte votre position pour analyser et améliorer les services de santé dans votre région. Pour permettre l\'accès aux données de position, sélectionnez \"Activer\" et confirmez à l\'écran qui suivra.</string>
 	<string name="locRequestOkButton">Activer</string>
@@ -12,7 +15,6 @@
 
 	<string name="connErrorTitle">Aucune connexion Internet</string>
 	<string name="connErrorMessage">Vous n\'êtes pas bien connecté à internet. Veuillez vérifier votre connexion et réessayer.</string>
-	<string name="connErrorRetry">RÉESSAYER</string>
 
 	<string name="waitMigration">Veuillez attendre que la migration de données termine</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
 	<string name="btnSave">Save</string>
 	<string name="btnCancel">Cancel</string>
 	<string name="btnContinue">Continue</string>
+	<string name="btnMoreInfo">More info</string>
+	<string name="btnRetry">Retry</string>
 	<string name="btnQuit">Quit</string>
 
 	<string name="mnuGotoTestPages">Android Test Pages</string>
@@ -58,7 +60,6 @@
 
     <string name="connErrorTitle">No Internet Connection</string>
 	<string name="connErrorMessage">You don\'t seem to be connected to the Internet. Please check your connection and try again.</string>
-	<string name="connErrorRetry">RETRY</string>
 
 	<string name="waitMigration">Please wait until the migration process is finished</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -55,4 +55,11 @@
 	<string name="loadingIconDescription">Loading…</string>
 	<string name="upgradingTitle">Upgrading your app</string>
 	<string name="upgradingMessage">You\'re upgrading to the latest version. Please wait while your data is being migrated.</string>
+
+    <string name="connErrorTitle">No Internet Connection</string>
+	<string name="connErrorMessage">You don\'t seem to be connected to the Internet. Please check your connection and try again.</string>
+	<string name="connErrorRetry">RETRY</string>
+
+	<string name="backToExit">Please press back again to exit</string>
+	<string name="waitMigration">Please wait until the migration process is finished</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -60,6 +60,5 @@
 	<string name="connErrorMessage">You don\'t seem to be connected to the Internet. Please check your connection and try again.</string>
 	<string name="connErrorRetry">RETRY</string>
 
-	<string name="backToExit">Please press back again to exit</string>
 	<string name="waitMigration">Please wait until the migration process is finished</string>
 </resources>

--- a/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -147,7 +147,10 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 		if (xWalkMigration.hasToMigrate()) {
 			log(this, "onStart() :: Running Crosswalk migration ...");
 			isMigrationRunning = true;
-			startActivity(new Intent(this, UpgradingActivity.class));
+			Intent intent = new Intent(this, UpgradingActivity.class)
+				.putExtra("isClosable", false)
+				.putExtra("backPressedMessage", getString(R.string.waitMigration));
+			startActivity(intent);
 			xWalkMigration.run();
 		} else {
 			trace(this, "onStart() :: Crosswalk installation not found - skipping migration");

--- a/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -2,9 +2,11 @@ package org.medicmobile.webapp.mobile;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.app.ActivityManager;
+import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.net.ConnectivityManager;
@@ -39,6 +41,7 @@ import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.MedicLog.warn;
 import static org.medicmobile.webapp.mobile.SimpleJsonClient2.redactUrl;
 import static org.medicmobile.webapp.mobile.Utils.createUseragentFrom;
+import static org.medicmobile.webapp.mobile.Utils.isConnectionError;
 import static org.medicmobile.webapp.mobile.Utils.isUrlRelated;
 import static org.medicmobile.webapp.mobile.Utils.restartApp;
 
@@ -133,6 +136,7 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 			toast(redactUrl(appUrl));
 		}
 
+		registerRetryConnectionBroadcastReceiver();
 	}
 
 	@Override
@@ -433,10 +437,19 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 			@Override
 			public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
 				String failingUrl = request.getUrl().toString();
-				trace(this, "onReceivedLoadError() :: url: %s, error code: %s, description: %s",
+				log(this, "onReceivedLoadError() :: url: %s, error code: %s, description: %s",
 						failingUrl, error.getErrorCode(), error.getDescription());
 				if (!getRootUrl().equals(failingUrl)) {
 					super.onReceivedError(view, request, error);
+				} else if (isConnectionError(error)) {
+					Intent intent = new Intent(view.getContext(), ConnectionErrorActivity.class);
+					if (isMigrationRunning) {
+						// Activity is not closable if the migration is running
+						intent
+							.putExtra("isClosable", false)
+							.putExtra("backPressedMessage", getResources().getString(R.string.waitMigration));
+					}
+					startActivity(intent);
 				} else {
 					evaluateJavascript(String.format(
 							"var body = document.evaluate('/html/body', document);" +
@@ -474,10 +487,31 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 					trace(this, "onPageStarted() :: Cookies loaded, skipping restart");
 				}
 			}
+
+			@Override public void onPageFinished(WebView view, String url) {
+				trace(this, "onPageFinished() :: url: %s", url);
+				// Broadcast the event so if the connection error
+				// activity is listening it will close
+				sendBroadcast(new Intent("onPageFinished"));
+			}
 		});
 	}
 
 	private void toast(String message) {
 		Toast.makeText(container.getContext(), message, Toast.LENGTH_LONG).show();
+	}
+
+	private void registerRetryConnectionBroadcastReceiver() {
+		BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+			@Override public void onReceive(Context context, Intent intent) {
+				String action = intent.getAction();
+				if (action.equals("retryConnection")) {
+					// user fixed the connection and asked the app
+					// to retry the load from the connection error activity
+					evaluateJavascript("window.location.reload()", false);
+				}
+			}
+		};
+		registerReceiver(broadcastReceiver, new IntentFilter("retryConnection"));
 	}
 }

--- a/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/EmbeddedBrowserActivity.java
@@ -40,6 +40,7 @@ import static org.medicmobile.webapp.mobile.MedicLog.log;
 import static org.medicmobile.webapp.mobile.MedicLog.trace;
 import static org.medicmobile.webapp.mobile.MedicLog.warn;
 import static org.medicmobile.webapp.mobile.SimpleJsonClient2.redactUrl;
+import static org.medicmobile.webapp.mobile.Utils.connectionErrorToString;
 import static org.medicmobile.webapp.mobile.Utils.createUseragentFrom;
 import static org.medicmobile.webapp.mobile.Utils.isConnectionError;
 import static org.medicmobile.webapp.mobile.Utils.isUrlRelated;
@@ -442,12 +443,14 @@ public class EmbeddedBrowserActivity extends LockableActivity {
 				if (!getRootUrl().equals(failingUrl)) {
 					super.onReceivedError(view, request, error);
 				} else if (isConnectionError(error)) {
+					String connErrorInfo = connectionErrorToString(error);
 					Intent intent = new Intent(view.getContext(), ConnectionErrorActivity.class);
+					intent.putExtra("connErrorInfo", connErrorInfo);
 					if (isMigrationRunning) {
 						// Activity is not closable if the migration is running
 						intent
 							.putExtra("isClosable", false)
-							.putExtra("backPressedMessage", getResources().getString(R.string.waitMigration));
+							.putExtra("backPressedMessage", getString(R.string.waitMigration));
 					}
 					startActivity(intent);
 				} else {

--- a/src/webview/java/org/medicmobile/webapp/mobile/UpgradingActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/UpgradingActivity.java
@@ -3,6 +3,10 @@ package org.medicmobile.webapp.mobile;
 import android.os.Bundle;
 import android.view.Window;
 
+
+/**
+ * Activity displayed when the upgrade from XWalk to WebView is running.
+ */
 public class UpgradingActivity extends LockableActivity {
 
 	@Override public void onCreate(Bundle savedInstanceState) {

--- a/src/webview/java/org/medicmobile/webapp/mobile/UpgradingActivity.java
+++ b/src/webview/java/org/medicmobile/webapp/mobile/UpgradingActivity.java
@@ -7,7 +7,7 @@ import android.view.Window;
 /**
  * Activity displayed when the upgrade from XWalk to WebView is running.
  */
-public class UpgradingActivity extends LockableActivity {
+public class UpgradingActivity extends ClosableAppActivity {
 
 	@Override public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);


### PR DESCRIPTION
Activity + Layout to catch connection errors and give the user the ability to retry after fix the connection, and the ability to leave the application only if it doesn't cause the user to lost data (when user is migrating the app).

Issue: https://github.com/medic/medic-android/issues/163

### Implementation

A new activity and layout were implemented to catch connection errors and avoid the not so friendly Chrome view error screen. The implementation only covers Webview (and therefore the migration from XWalk to Webview). I tried to use the same implementation in XWalk (though I needed to make some adaptations of how XWalk catch errors) and it worked, but for some weird error it cause the app to fail after restart if the user leaves the app with the error activity, so taking into account that is not a priority and we are going to drop XWalk soon, I left Xwalk error management as it is now.

### Improvements

- Spinner while the app retries the connection.
- Always show a button "Retry" so the user can retry after recover the connection. Previously the button was not displayed some times as show in the screenshot from the ticket.
- User can retry many times without problems. Previously retrying with the html button "Retry" many times caused the button to disappear at some point, some times even after the first try.
- Allow to close the app pressing back in the login workflow. In the previous implementation leaving the app and entering again caused the user to see again the connection error until force the full close of the app from the app manager of Android. Now because pressing back really close the app, the second time is opened the loading starts again.
- In the migration process the error activity does not allow the user to leave the app because testing that scenario in my device caused some times to lose the data, so instead the user sees a "toast" message saying that it needs to wait until the migration process finish.
- A button "More info" is provided to see the error code that caused the connection error.

### Testing

#### Login page

Here is a recording with the user trying to load the app and sign-in for the first time. It shows different scenarios: user entering without connection, then retry again without connection. User press back living the app. Then enter again into the app, the app allows to sign-in without force closing the app when the connection is recovered.

![Medic Android - No Internet - Login 2](https://user-images.githubusercontent.com/1608415/112219036-3f511100-8c03-11eb-8245-a8df1407ffae.gif)

#### Migration process

In the recording below the app was installed on top of the Xwalk version. It shows how the migration popup is shown and immediately the lack of connection is displayed by the connection error activity. The user then reconnects the WiFi and the process continue without problems.

![Medic Android - No Internet - Migration running 2](https://user-images.githubusercontent.com/1608415/112219405-b25a8780-8c03-11eb-82f1-11a8068b2b4c.gif)

Below the user tries to leave the app pressing back but the exit is prevented and a "toast" message is displayed asking the user to wait the migration process to finish:

![Medic Android - No Internet - Migration running - Wait](https://user-images.githubusercontent.com/1608415/112219578-f2216f00-8c03-11eb-9d81-8d3ea2c19c29.gif)

Finally, here is the button "More info" showing the error code:

![Medic Android - No Internet - More Info](https://user-images.githubusercontent.com/1608415/112219712-272dc180-8c04-11eb-92da-8d6f20251421.gif)


### Notes

- The activity only intercepts connection errors when the app fails to load an URL (login) or reload the current page (migration process, or when the user press "Retry"). Ajax calls from the webapp are not intercepted, and are handled by the CHT webapp itself, nothing change there.
- When a page fails to load like the login page, the old Chrome error page is visible for a fraction of seconds until is hidden by the connection error activity on top, we cannot avoid that :disappointed: . 
- A phone with black theme was used for the recording (Android 6). I also tested the features with an Android 11 phone with normal theme and the new activity layout has white background with black text as the mockup from the ticket.
- To test the migration workflow, check the steps here: https://github.com/medic/medic-android/pull/162#issuecomment-798546578.